### PR TITLE
Fix #5: strip %checks and warn

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -1,5 +1,8 @@
 const t = require("@babel/types");
 
+const locToString = (loc) => 
+  `${loc.start.line}:${loc.start.column}-${loc.end.line}:${loc.end.column}`;
+
 const transform = {
   Program(path) {
     const {body} = path.node;
@@ -43,7 +46,23 @@ const transform = {
     path.replaceWith(t.tsAnyKeyword());
   },
 
-  // All non-leaf nodes must be processed on exit()
+  // It's okay to process these non-leaf nodes on enter()
+  // since we're modifying them in a way doesn't affect
+  // the processing of other nodes.
+  FunctionDeclaration(path) {
+    console.warn(`removing %checks at ${locToString(path.node.predicate.loc)}`);
+    delete path.node.predicate;
+  },
+  FunctionExpression(path) {
+    console.warn(`removing %checks at ${locToString(path.node.predicate.loc)}`);
+    delete path.node.predicate;
+  },
+  ArrowFunctionExpression(path) {
+    console.warn(`removing %checks at ${locToString(path.node.predicate.loc)}`);
+    delete path.node.predicate;
+  },
+
+  // All other non-leaf nodes must be processed on exit()
   TypeAnnotation: {
     exit(path) {
       const {typeAnnotation} = path.node;

--- a/test/fixtures/function-types/predicate01/flow.js
+++ b/test/fixtures/function-types/predicate01/flow.js
@@ -1,0 +1,3 @@
+function isString(y): %checks {
+  return typeof y === "string";
+}  

--- a/test/fixtures/function-types/predicate01/ts.js
+++ b/test/fixtures/function-types/predicate01/ts.js
@@ -1,0 +1,3 @@
+function isString(y) {
+  return typeof y === "string";
+}

--- a/test/fixtures/function-types/predicate02/flow.js
+++ b/test/fixtures/function-types/predicate02/flow.js
@@ -1,0 +1,3 @@
+const isString = function (y): %checks {
+  return typeof y === "isString";
+}

--- a/test/fixtures/function-types/predicate02/ts.js
+++ b/test/fixtures/function-types/predicate02/ts.js
@@ -1,0 +1,3 @@
+const isString = function (y) {
+  return typeof y === "isString";
+};

--- a/test/fixtures/function-types/predicate03/flow.js
+++ b/test/fixtures/function-types/predicate03/flow.js
@@ -1,0 +1,1 @@
+const isString = (y): %checks => typeof y === "isString";

--- a/test/fixtures/function-types/predicate03/ts.js
+++ b/test/fixtures/function-types/predicate03/ts.js
@@ -1,0 +1,1 @@
+const isString = y => typeof y === "isString";


### PR DESCRIPTION
The warning even includes the location within the file.  I'll add the file name to the warning in a future PR.