### PR TITLE
Rewrite imports, fixes #7

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -1,3 +1,4 @@
+const path = require("path");
 const t = require("@babel/types");
 
 const locToString = (loc) => 
@@ -466,6 +467,21 @@ const transform = {
     exit(path) {
       const {id, typeParameters} = path.node;
       path.replaceWith(t.tsExpressionWithTypeArguments(id, typeParameters));
+    }
+  },
+  ImportDeclaration: {
+    exit(path) {
+      path.node.importKind = "value";
+      // TODO: make this configurable so we can output .ts[x]?
+      const src = path.node.source.value.startsWith("./")
+        ? path.node.source.value.replace(/\.js[x]?$/, "")
+        : path.node.source.value;
+      path.node.source = t.stringLiteral(src)
+    }
+  },
+  ImportSpecifier: {
+    exit(path) {
+      path.node.importKind = "value";
     }
   },
 };

--- a/test/fixtures/imports/default_import/flow.js
+++ b/test/fixtures/imports/default_import/flow.js
@@ -1,0 +1,1 @@
+import type A from "./deps.js";

--- a/test/fixtures/imports/default_import/ts.js
+++ b/test/fixtures/imports/default_import/ts.js
@@ -1,0 +1,1 @@
+import A from "./deps";

--- a/test/fixtures/imports/import_node_module/flow.js
+++ b/test/fixtures/imports/import_node_module/flow.js
@@ -1,0 +1,1 @@
+import type A from "dep";

--- a/test/fixtures/imports/import_node_module/ts.js
+++ b/test/fixtures/imports/import_node_module/ts.js
@@ -1,0 +1,1 @@
+import A from "dep";

--- a/test/fixtures/imports/named_import_declaration_kind/flow.js
+++ b/test/fixtures/imports/named_import_declaration_kind/flow.js
@@ -1,0 +1,1 @@
+import type { A, B } from "./dep.js";

--- a/test/fixtures/imports/named_import_declaration_kind/ts.js
+++ b/test/fixtures/imports/named_import_declaration_kind/ts.js
@@ -1,0 +1,1 @@
+import { A, B } from "./dep";

--- a/test/fixtures/imports/named_import_specifier_kind/flow.js
+++ b/test/fixtures/imports/named_import_specifier_kind/flow.js
@@ -1,0 +1,1 @@
+import { type A, type B, C } from "./dep.js";

--- a/test/fixtures/imports/named_import_specifier_kind/ts.js
+++ b/test/fixtures/imports/named_import_specifier_kind/ts.js
@@ -1,0 +1,1 @@
+import { A, B, C } from "./dep";

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,7 +5,7 @@ const convert = require("../src/convert.js");
 
 const failingTestNames = ["spread03", "spread04"];
 
-describe("laminar", () => {
+describe("flow-to-ts", () => {
   const suites = fs.readdirSync(path.join(__dirname, "fixtures"));
   for (const suiteName of suites) {
     describe(suiteName, () => {


### PR DESCRIPTION
This PR rewrites flow imports in the following ways:
- all `type` specifiers are dropped
- the file extension is dropped as well.