### PR TITLE
Fix issue with missing leading and trailing comments in some nodes

### DIFF
--- a/src/compute-newlines.js
+++ b/src/compute-newlines.js
@@ -74,7 +74,7 @@ const computeNewlines = (node) => {
     }
     newlines.push(lines);
   }
-  
+
   const trailingLines = new Array(node.loc.end.line - children[children.length - 1].loc.end.line);
   if (children[children.length - 1].trailingComments) {
     for (const comment of children[children.length - 1].trailingComments) {

--- a/src/convert.js
+++ b/src/convert.js
@@ -23,6 +23,15 @@ const parseOptions = {
 const convert = (flowCode, options) => {
     const ast = parse(flowCode, parseOptions);
 
+    const comments = {
+        startLine: {},
+        endLine: {},
+    };
+    for (const comment of ast.comments) {
+        comments.startLine[comment.loc.start.line] = comment;
+        comments.endLine[comment.loc.end.line] = comment;
+    }
+
     // apply our transforms, traverse mutates the ast
     const state = {
         usedUtilityTypes: new Set(),
@@ -30,6 +39,7 @@ const convert = (flowCode, options) => {
             { inlineUtilityTypes: false },
             options,
         ),
+        comments,
     };
     traverse(ast, transform, null, state);
 

--- a/test/fixtures/comments/flow02/flow.js
+++ b/test/fixtures/comments/flow02/flow.js
@@ -1,0 +1,3 @@
+// @flow
+// leading comment
+let a: string;

--- a/test/fixtures/comments/flow02/ts.js
+++ b/test/fixtures/comments/flow02/ts.js
@@ -1,0 +1,3 @@
+
+// leading comment
+let a: string;

--- a/test/fixtures/formatting/line_comments01/flow.js
+++ b/test/fixtures/formatting/line_comments01/flow.js
@@ -1,5 +1,5 @@
-
-// foo
+// first leading comment
+// second leading comment
 const a = 5;
 
 // bar

--- a/test/fixtures/formatting/line_comments01/ts.js
+++ b/test/fixtures/formatting/line_comments01/ts.js
@@ -1,5 +1,5 @@
-
-// foo
+// first leading comment
+// second leading comment
 const a = 5;
 
 // bar

--- a/test/fixtures/formatting/object_newlines/flow.js
+++ b/test/fixtures/formatting/object_newlines/flow.js
@@ -5,5 +5,6 @@ const obj = {
 
     // y
     y: 10,
+    // trailing comment
 
 };

--- a/test/fixtures/formatting/object_newlines/ts.js
+++ b/test/fixtures/formatting/object_newlines/ts.js
@@ -5,5 +5,6 @@ const obj = {
 
   // y
   y: 10
+  // trailing comment
 
 };

--- a/test/fixtures/formatting/object_type_newlines/flow.js
+++ b/test/fixtures/formatting/object_type_newlines/flow.js
@@ -5,5 +5,6 @@ type Point = {
 
     // y
     y: number,
+    // trailing newline
 
 };

--- a/test/fixtures/formatting/object_type_newlines/ts.js
+++ b/test/fixtures/formatting/object_type_newlines/ts.js
@@ -5,5 +5,6 @@ type Point = {
 
   // y
   y: number;
+  // trailing newline
 
 };

--- a/test/fixtures/formatting/spacing03/flow.js
+++ b/test/fixtures/formatting/spacing03/flow.js
@@ -1,5 +1,6 @@
 const a = () => {
-  
+  // first leading comment
+  // second leading comment
   const b = 5;
 
 

--- a/test/fixtures/formatting/spacing03/ts.js
+++ b/test/fixtures/formatting/spacing03/ts.js
@@ -1,5 +1,6 @@
 const a = () => {
-
+  // first leading comment
+  // second leading comment
   const b = 5;
 
 


### PR DESCRIPTION
The missing comments were due to issues with the babylon parser not attaching comments to certain nodes in certain situations.  This fix is a workaround for those issues.  I'll file a bug report with babylon later.