### PR TITLE
Get things ready for publishing, partially addresses #65

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,5 @@
+.circleci
+.vscode
+coverage
+playground
+test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,10 @@
 {
   "name": "@khanacademy/flow-to-ts",
-  "version": "0.0.1",
+  "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/khan/flow-to-ts"
+  },
   "main": "src/convert.js",
   "license": "MIT",
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "flow-to-ts",
+  "name": "@khanacademy/flow-to-ts",
   "version": "0.0.1",
-  "main": "convert.js",
+  "main": "src/convert.js",
   "license": "MIT",
   "dependencies": {
     "@babel/core": "^7.4.0",


### PR DESCRIPTION
I ran `npm publish --dry-run` and saw the following output:
```
npm notice 
npm notice 📦  @khanacademy/flow-to-ts@0.1.0
npm notice === Tarball Contents === 
npm notice 646B    package.json                                          
npm notice 360B    README.md                                             
npm notice 105.2kB yarn.lock                                             
npm notice 6.1kB   babel-generator/lib/buffer.js                         
npm notice 2.5kB   babel-generator/lib/generators/base.js                
npm notice 3.9kB   babel-generator/lib/generators/classes.js             
npm notice 7.1kB   babel-generator/lib/generators/expressions.js         
npm notice 13.6kB  babel-generator/lib/generators/flow.js                
npm notice 3.1kB   babel-generator/lib/generators/index.js               
npm notice 3.0kB   babel-generator/lib/generators/jsx.js                 
npm notice 3.8kB   babel-generator/lib/generators/methods.js             
npm notice 5.2kB   babel-generator/lib/generators/modules.js             
npm notice 7.3kB   babel-generator/lib/generators/statements.js          
npm notice 864B    babel-generator/lib/generators/template-literals.js   
npm notice 4.7kB   babel-generator/lib/generators/types.js               
npm notice 14.6kB  babel-generator/lib/generators/typescript.js          
npm notice 2.4kB   babel-generator/lib/index.js                          
npm notice 3.2kB   babel-generator/lib/node/index.js                     
npm notice 7.8kB   babel-generator/lib/node/parentheses.js               
npm notice 5.1kB   babel-generator/lib/node/whitespace.js                
npm notice 13.9kB  babel-generator/lib/printer.js                        
npm notice 2.0kB   babel-generator/lib/source-map.js                     
npm notice 1.1kB   babel-generator/LICENSE                               
npm notice 447B    babel-generator/README.md                             
npm notice 488B    babel-traverse/lib/cache.js                           
npm notice 3.6kB   babel-traverse/lib/context.js                         
npm notice 345B    babel-traverse/lib/hub.js                             
npm notice 3.5kB   babel-traverse/lib/index.js                           
npm notice 4.3kB   babel-traverse/lib/path/ancestry.js                   
npm notice 1.6kB   babel-traverse/lib/path/comments.js                   
npm notice 5.4kB   babel-traverse/lib/path/context.js                    
npm notice 15.1kB  babel-traverse/lib/path/conversion.js                 
npm notice 9.1kB   babel-traverse/lib/path/evaluation.js                 
npm notice 6.1kB   babel-traverse/lib/path/family.js                     
npm notice 5.5kB   babel-traverse/lib/path/index.js                      
npm notice 3.8kB   babel-traverse/lib/path/inference/index.js            
npm notice 5.0kB   babel-traverse/lib/path/inference/inferer-reference.js
npm notice 6.8kB   babel-traverse/lib/path/inference/inferers.js         
npm notice 10.3kB  babel-traverse/lib/path/introspection.js              
npm notice 5.4kB   babel-traverse/lib/path/lib/hoister.js                
npm notice 1.3kB   babel-traverse/lib/path/lib/removal-hooks.js          
npm notice 5.1kB   babel-traverse/lib/path/lib/virtual-types.js          
npm notice 6.7kB   babel-traverse/lib/path/modification.js               
npm notice 1.3kB   babel-traverse/lib/path/removal.js                    
npm notice 7.0kB   babel-traverse/lib/path/replacement.js                
npm notice 1.2kB   babel-traverse/lib/scope/binding.js                   
npm notice 22.3kB  babel-traverse/lib/scope/index.js                     
npm notice 3.9kB   babel-traverse/lib/scope/lib/renamer.js               
npm notice 6.6kB   babel-traverse/lib/visitors.js                        
npm notice 1.1kB   babel-traverse/LICENSE                                
npm notice 930B    babel-traverse/package.json                           
npm notice 791B    babel-traverse/README.md                              
npm notice 4.0kB   src/compute-newlines.js                               
npm notice 1.9kB   src/convert.js                                        
npm notice 18.5kB  src/transform.js                                      
npm notice === Tarball Details === 
npm notice name:          @khanacademy/flow-to-ts                 
npm notice version:       0.1.0                                   
npm notice package size:  84.9 kB                                 
npm notice unpacked size: 387.2 kB                                
npm notice shasum:        47ec7f74df6353ec576f988d8e790aa66d0470e1
npm notice integrity:     sha512-eXhEZdqRjQ2w5[...]UxPNACV2w+f5w==
npm notice total files:   55                                      
npm notice 
+ @khanacademy/flow-to-ts@0.1.0
```