### PR TITLE
Simplify options code

### DIFF
--- a/playground/src/app.tsx
+++ b/playground/src/app.tsx
@@ -29,17 +29,15 @@ type State = {
   options: Options;
 };
 
-// TODO: stop nest params
 const defaultOptions: Options = {
-  prettier: {
-    semi: true,
-    singleQuote: false,
-    tabWidth: 4,
-    trailingComma: "all",
-    bracketSpacing: false,
-    arrowParens: "avoid",
-    printWidth: 80
-  },
+  prettier: true,
+  semi: true,
+  singleQuote: false,
+  tabWidth: 4,
+  trailingComma: "all",
+  bracketSpacing: false,
+  arrowParens: "avoid",
+  printWidth: 80,
   inlineUtilityTypes: false
 };
 
@@ -62,34 +60,34 @@ const maybeDecodeHash = (hash: string): { code: string; options: Options } => {
 
     const options = {} as Options;
 
-    if (urlParams.prettier && defaultOptions.prettier) {
-      options.prettier = { ...defaultOptions.prettier };
-      if (urlParams.semi) {
-        options.prettier.semi = Boolean(parseInt(urlParams.semi));
-      }
-      if (urlParams.singleQuote) {
-        options.prettier.singleQuote = Boolean(parseInt(urlParams.singleQuote));
-      }
-      if (urlParams.tabWidth) {
-        options.prettier.tabWidth = parseInt(urlParams.tabWidth);
-      }
-      if (urlParams.trailingComma) {
-        options.prettier.trailingComma = urlParams.trailingComma;
-      }
-      if (urlParams.bracketSpacing) {
-        options.prettier.bracketSpacing = Boolean(
-          parseInt(urlParams.bracketSpacing)
-        );
-      }
-      if (urlParams.arrowParens) {
-        options.prettier.arrowParens = urlParams.arrowParams;
-      }
-      if (urlParams.printWidth) {
-        options.prettier.printWidth = parseInt(urlParams.printWidth);
-      }
+    if (urlParams.prettier) {
+      options.prettier = Boolean(parseInt(urlParams.prettier));
+    }
+    if (urlParams.semi) {
+      options.semi = Boolean(parseInt(urlParams.semi));
+    }
+    if (urlParams.singleQuote) {
+      options.singleQuote = Boolean(parseInt(urlParams.singleQuote));
+    }
+    if (urlParams.tabWidth) {
+      options.tabWidth = parseInt(urlParams.tabWidth);
+    }
+    if (urlParams.trailingComma) {
+      options.trailingComma = urlParams.trailingComma;
+    }
+    if (urlParams.bracketSpacing) {
+      options.bracketSpacing = Boolean(parseInt(urlParams.bracketSpacing));
+    }
+    if (urlParams.arrowParens) {
+      options.arrowParens = urlParams.arrowParams;
+    }
+    if (urlParams.printWidth) {
+      options.printWidth = parseInt(urlParams.printWidth);
     }
     if (urlParams.inlineUtilityTypes) {
-      options.inlineUtilityTypes = urlParams.inlineUtilityTypes;
+      options.inlineUtilityTypes = Boolean(
+        parseInt(urlParams.inlineUtilityTypes)
+      );
     }
 
     const code = atob(urlParams.code);
@@ -105,14 +103,7 @@ const encodeHash = (code: string, options: Options) => {
     code: btoa(code)
   } as any;
 
-  const { prettier, ...restOptions } = options;
-  if (prettier) {
-    urlParams.prettier = true;
-    for (const [key, value] of Object.entries(prettier)) {
-      urlParams[key] = value;
-    }
-  }
-  for (const [key, value] of Object.entries(restOptions)) {
+  for (const [key, value] of Object.entries(options)) {
     urlParams[key] = value;
   }
 
@@ -249,10 +240,8 @@ class App extends React.Component<Props, State> {
       try {
         const tsCode = convert(flowCode, this.state.options);
         this.tsEditor.setValue(tsCode);
-        const prettier = this.state.options.prettier;
-        this.tsEditor
-          .getModel()
-          .updateOptions({ tabSize: prettier ? prettier.tabWidth : 2 });
+        const { options } = this.state;
+        this.tsEditor.getModel().updateOptions({ tabSize: options.tabWidth });
       } catch (e) {
         debugger;
         this.setState({ error: e.toString() });

--- a/playground/src/options-panel.tsx
+++ b/playground/src/options-panel.tsx
@@ -17,9 +17,8 @@ const examples = {
   utilityTypes
 };
 
-console.log(examples);
-
-type PrettierOptions = {
+export type Options = {
+  prettier: boolean;
   semi: boolean;
   singleQuote: boolean;
   tabWidth: number;
@@ -27,10 +26,6 @@ type PrettierOptions = {
   bracketSpacing: boolean;
   arrowParens: "avoid" | "always";
   printWidth: number;
-};
-
-export type Options = {
-  prettier: PrettierOptions | false;
   inlineUtilityTypes: boolean;
 };
 
@@ -40,31 +35,9 @@ type Props = {
   onCodeChange: (newCode: string) => unknown;
 };
 
-const defaultPrettierOptions = {
-  semi: true,
-  singleQuote: false,
-  tabWidth: 4,
-  trailingComma: "all",
-  bracketSpacing: false,
-  arrowParens: "avoid",
-  printWidth: 80
-} as PrettierOptions;
-
 class OptionsPanel extends React.Component<Props> {
-  prettierOptions: PrettierOptions;
-
   constructor(props: Props) {
     super(props);
-
-    this.prettierOptions = props.options.prettier || defaultPrettierOptions;
-  }
-
-  componentDidUpdate() {
-    // Store the most recent copy of prettier options so that we can show
-    // them as disabled if someone disables prettier.
-    if (this.props.options.prettier) {
-      this.prettierOptions = this.props.options.prettier;
-    }
   }
 
   handleExampleChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
@@ -86,7 +59,6 @@ class OptionsPanel extends React.Component<Props> {
     } as React.CSSProperties;
 
     const { options, onOptionsChange } = this.props;
-    const prettier = options.prettier ? options.prettier : this.prettierOptions;
 
     return (
       <div style={optionsPanel}>
@@ -121,7 +93,7 @@ class OptionsPanel extends React.Component<Props> {
             onChange={e => {
               onOptionsChange({
                 ...options,
-                prettier: e.currentTarget.checked ? this.prettierOptions : false
+                prettier: e.currentTarget.checked
               });
             }}
           />
@@ -132,15 +104,12 @@ class OptionsPanel extends React.Component<Props> {
           <input
             id="semicolons"
             type="checkbox"
-            checked={prettier.semi}
+            checked={options.semi}
             disabled={!options.prettier}
             onChange={e => {
               onOptionsChange({
                 ...options,
-                prettier: {
-                  ...prettier,
-                  semi: e.currentTarget.checked
-                }
+                semi: e.currentTarget.checked
               });
             }}
           />
@@ -150,15 +119,12 @@ class OptionsPanel extends React.Component<Props> {
           <input
             id="single-quotes"
             type="checkbox"
-            checked={prettier.singleQuote}
+            checked={options.singleQuote}
             disabled={!options.prettier}
             onChange={e => {
               onOptionsChange({
                 ...options,
-                prettier: {
-                  ...prettier,
-                  singleQuote: e.currentTarget.checked
-                }
+                singleQuote: e.currentTarget.checked
               });
             }}
           />
@@ -168,14 +134,12 @@ class OptionsPanel extends React.Component<Props> {
           <input
             id="bracket-spacing"
             type="checkbox"
-            checked={prettier.bracketSpacing}
+            checked={options.bracketSpacing}
+            disabled={!options.prettier}
             onChange={e => {
               onOptionsChange({
                 ...options,
-                prettier: {
-                  ...prettier,
-                  bracketSpacing: e.currentTarget.checked
-                }
+                bracketSpacing: e.currentTarget.checked
               });
             }}
           />
@@ -184,15 +148,12 @@ class OptionsPanel extends React.Component<Props> {
           </label>
           <select
             id="tab-width"
-            value={prettier.tabWidth}
+            value={options.tabWidth}
             disabled={!options.prettier}
             onChange={e => {
               onOptionsChange({
                 ...options,
-                prettier: {
-                  ...prettier,
-                  tabWidth: Number(e.currentTarget.value)
-                }
+                tabWidth: Number(e.currentTarget.value)
               });
             }}
           >
@@ -204,15 +165,12 @@ class OptionsPanel extends React.Component<Props> {
           </label>
           <select
             id="arrow-parens"
-            value={prettier.arrowParens}
+            value={options.arrowParens}
             disabled={!options.prettier}
             onChange={e => {
               onOptionsChange({
                 ...options,
-                prettier: {
-                  ...prettier,
-                  arrowParens: e.currentTarget.value as "avoid" | "always"
-                }
+                arrowParens: e.currentTarget.value as "avoid" | "always"
               });
             }}
           >
@@ -224,15 +182,12 @@ class OptionsPanel extends React.Component<Props> {
           </label>
           <select
             id="trailing-commas"
-            value={prettier.trailingComma}
+            value={options.trailingComma}
             disabled={!options.prettier}
             onChange={e => {
               onOptionsChange({
                 ...options,
-                prettier: {
-                  ...prettier,
-                  trailingComma: e.currentTarget.value as "none" | "es5" | "all"
-                }
+                trailingComma: e.currentTarget.value as "none" | "es5" | "all"
               });
             }}
           >
@@ -246,15 +201,12 @@ class OptionsPanel extends React.Component<Props> {
           <input
             id="print-width"
             type="text"
-            value={prettier.printWidth}
+            value={options.printWidth}
             disabled={!options.prettier}
             onChange={e => {
               onOptionsChange({
                 ...options,
-                prettier: {
-                  ...prettier,
-                  printWidth: Number(e.currentTarget.value)
-                }
+                printWidth: Number(e.currentTarget.value)
               });
             }}
           />

--- a/src/cli.js
+++ b/src/cli.js
@@ -15,6 +15,10 @@ const cli = argv => {
       "add semi-colons, defaults to 'false' (depends on --prettier)"
     )
     .option(
+      "--single-quote",
+      "use single quotes instead of double quotes, defaults to 'false' (depends on --prettier)"
+    )
+    .option(
       "--tab-width [width]",
       "size of tabs (depends on --prettier)",
       /2|4/,
@@ -49,16 +53,14 @@ const cli = argv => {
 
   const options = {
     inlineUtilityTypes: Boolean(program.inlineUtilityTypes),
-    prettier: program.prettier
-      ? {
-          semi: Boolean(program.semi),
-          tabWidth: parseInt(program.tabWidth),
-          trailingComma: program.trailingComma,
-          bracketSpacing: Boolean(program.bracketSpacing),
-          arrowParens: program.arrowParens,
-          printWidth: program.printWidth
-        }
-      : false
+    prettier: program.prettier,
+    semi: Boolean(program.semi),
+    singleQuote: Boolean(program.singleQuote),
+    tabWidth: parseInt(program.tabWidth),
+    trailingComma: program.trailingComma,
+    bracketSpacing: Boolean(program.bracketSpacing),
+    arrowParens: program.arrowParens,
+    printWidth: program.printWidth
   };
 
   const files = new Set();

--- a/src/convert.js
+++ b/src/convert.js
@@ -51,10 +51,17 @@ const convert = (flowCode, options) => {
   }
 
   if (options && options.prettier) {
-    const prettierOptions = Object.assign(
-      { parser: "typescript", plugins },
-      typeof options.prettier === "object" ? options.prettier : {}
-    );
+    const prettierOptions = {
+      parser: "typescript",
+      plugins,
+      semi: options.semi,
+      singleQuote: options.singleQuote,
+      tabWidth: options.tabWidth,
+      trailingComma: options.trailingComma,
+      bracketSpacing: options.bracketSpacing,
+      arrowParens: options.arrowParens,
+      printWidth: options.printWidth
+    };
     return prettier.format(tsCode, prettierOptions).trim();
   } else {
     return tsCode;

--- a/test/fixtures/formatting/prettier_options/options.json
+++ b/test/fixtures/formatting/prettier_options/options.json
@@ -1,8 +1,7 @@
 {
-    "prettier": {
-        "semi": false,
-        "singleQuote": true,
-        "tabWidth": 4,
-        "trailingComma": "all"
-    }
+    "prettier": true,
+    "semi": false,
+    "singleQuote": true,
+    "tabWidth": 4,
+    "trailingComma": "all"
 }


### PR DESCRIPTION
There was a TODO to stop nesting the prettier options as a sub-object with options.  This PR does that TODO.  I did some manual test of the playground to ensure that saving/restoring of options works.