### PR TITLE
Fixes #99: Support JSX in the playground

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -4,8 +4,9 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "monaco-editor": "^0.16.2",
+    "codemirror": "^5.46.0",
     "react": "^16.8.5",
+    "react-codemirror2": "^6.0.0",
     "react-dom": "^16.8.5"
   },
   "devDependencies": {
@@ -17,14 +18,12 @@
     "@babel/preset-typescript": "^7.3.3",
     "@types/react": "^16.8.8",
     "@types/react-dom": "^16.8.3",
-    "@types/react-monaco-editor": "^0.16.0",
     "@types/webpack-env": "^1.13.9",
     "babel-loader": "^8.0.5",
     "copy-webpack-plugin": "^5.0.3",
     "css-loader": "^2.1.1",
     "file-loader": "^3.0.1",
     "html-webpack-plugin": "^3.2.0",
-    "monaco-editor-webpack-plugin": "^1.7.0",
     "raw-loader": "^2.0.0",
     "style-loader": "^0.23.1",
     "typescript": "^3.3.4000",

--- a/playground/src/app.tsx
+++ b/playground/src/app.tsx
@@ -45,7 +45,7 @@ type State = {
   flowCode: string;
   tsCode: string;
   errors: string[];
-  focusedEditor: monaco.editor.IStandaloneCodeEditor;
+  focusedEditor: any;
   options: Options;
   scroll: { x: number; y: number };
 };
@@ -310,6 +310,9 @@ class App extends React.Component<Props, State> {
             onScroll={(editor, data) => {
               this.tsEditor.scrollTo(data.left, data.top);
             }}
+            onFocus={(editor, event) =>
+              this.setState({ focusedEditor: editor })
+            }
             scroll={this.state.scroll}
           />
           <div style={flowOverlayStyle}>
@@ -345,6 +348,9 @@ class App extends React.Component<Props, State> {
             onScroll={(editor, data) => {
               this.flowEditor && this.flowEditor.scrollTo(data.left, data.top);
             }}
+            onFocus={(editor, event) =>
+              this.setState({ focusedEditor: editor })
+            }
             scroll={this.state.scroll}
           />
           <div style={tsOverlayStyle} />

--- a/playground/src/app.tsx
+++ b/playground/src/app.tsx
@@ -123,7 +123,7 @@ class App extends React.Component<Props, State> {
           }
 
           this.flow = flow;
-          this.typeCheck();
+          this.typeCheck(this.state.flowCode);
         });
     });
   }
@@ -138,7 +138,7 @@ class App extends React.Component<Props, State> {
       try {
         const tsCode = convert(flowCode, this.state.options);
         this.setState({ tsCode });
-        this.typeCheck();
+        this.typeCheck(flowCode);
       } catch (e) {
         this.setState({ errors: [e.toString()] });
         console.log(e);
@@ -152,16 +152,15 @@ class App extends React.Component<Props, State> {
       this.setState({ flowCode });
       const tsCode = convert(flowCode, this.state.options);
       this.setState({ tsCode });
-      this.typeCheck();
+      this.typeCheck(flowCode);
     } catch (e) {
       this.setState({ errors: [e.toString()] });
       console.log(e);
     }
   }
 
-  typeCheck() {
+  typeCheck(flowCode: string) {
     if (this.flow) {
-      const flowCode = this.state.flowCode;
       const errors = this.flow.checkContent("-", flowCode);
       console.log(errors);
       if (errors.length > 0) {
@@ -262,7 +261,7 @@ class App extends React.Component<Props, State> {
         <OptionsPanel
           options={this.state.options}
           onOptionsChange={options => this.setState({ options })}
-          onCodeChange={code => this.flowEditor.setValue(code)}
+          onCodeChange={code => this.update(code)}
         />
         <div style={tabContainerStyle}>
           <div

--- a/playground/templates/index.html
+++ b/playground/templates/index.html
@@ -5,6 +5,23 @@
         overscroll-behavior: none;
         margin: 0;
       }
+      .react-codemirror2 {
+        display: flex;
+        flex-direction: column;
+        flex-grow: 1;
+      }
+      .CodeMirror {
+        font-size: 18px;
+        flex-grow: 1;
+      }
+      .CodeMirror-gutter {
+        min-width: 40px;
+      }
+      .CodeMirror-scroll {
+        height: 100%;
+        overflow-y: hidden;
+        overflow-x: auto;
+      }
     </style>
   </head>
   <body>

--- a/playground/webpack.config.js
+++ b/playground/webpack.config.js
@@ -1,5 +1,4 @@
 const path = require("path");
-const MonacoWebpackPlugin = require("monaco-editor-webpack-plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const CopyWebpackPlugin = require("copy-webpack-plugin");
 
@@ -41,7 +40,6 @@ module.exports = {
     extensions: [".ts", ".tsx", ".js", ".json"]
   },
   plugins: [
-    new MonacoWebpackPlugin(),
     new HtmlWebpackPlugin({
       template: "./templates/index.html"
     }),

--- a/playground/yarn.lock
+++ b/playground/yarn.lock
@@ -680,14 +680,6 @@
     lodash "^4.17.11"
     to-fast-properties "^2.0.0"
 
-"@types/anymatch@*":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@types/anymatch/-/anymatch-1.3.1.tgz#336badc1beecb9dacc38bea2cf32adf627a8421a"
-
-"@types/node@*":
-  version "11.13.0"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-11.13.0.tgz#b0df8d6ef9b5001b2be3a94d909ce3c29a80f9e1"
-
 "@types/prop-types@*":
   version "15.7.0"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.0.tgz#4c48fed958d6dcf9487195a0ef6456d5f6e0163a"
@@ -698,12 +690,6 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-monaco-editor@^0.16.0":
-  version "0.16.0"
-  resolved "https://registry.yarnpkg.com/@types/react-monaco-editor/-/react-monaco-editor-0.16.0.tgz#12913ab07221f3335eb56d12d38b9d310643db2f"
-  dependencies:
-    react-monaco-editor "*"
-
 "@types/react@*", "@types/react@^16.8.8":
   version "16.8.8"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.8.8.tgz#4b60a469fd2469f7aa6eaa0f8cfbc51f6d76e662"
@@ -711,29 +697,9 @@
     "@types/prop-types" "*"
     csstype "^2.2.0"
 
-"@types/tapable@*":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@types/tapable/-/tapable-1.0.4.tgz#b4ffc7dc97b498c969b360a41eee247f82616370"
-
-"@types/uglify-js@*":
-  version "3.0.4"
-  resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.0.4.tgz#96beae23df6f561862a830b4288a49e86baac082"
-  dependencies:
-    source-map "^0.6.1"
-
 "@types/webpack-env@^1.13.9":
   version "1.13.9"
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.13.9.tgz#a67287861c928ebf4159a908d1fb1a2a34d4097a"
-
-"@types/webpack@^4.4.19":
-  version "4.4.27"
-  resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.4.27.tgz#8bb9429185977a6b3b9e6e6132f561066aa7e7c2"
-  dependencies:
-    "@types/anymatch" "*"
-    "@types/node" "*"
-    "@types/tapable" "*"
-    "@types/uglify-js" "*"
-    source-map "^0.6.0"
 
 "@webassemblyjs/ast@1.8.5":
   version "1.8.5"
@@ -1330,6 +1296,11 @@ cliui@^4.0.0:
 code-point-at@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/code-point-at/-/code-point-at-1.1.0.tgz#0d070b4d043a5bea33a2f1a40e2edb3d9a4ccf77"
+
+codemirror@^5.46.0:
+  version "5.46.0"
+  resolved "https://registry.yarnpkg.com/codemirror/-/codemirror-5.46.0.tgz#be3591572f88911e0105a007c324856a9ece0fb7"
+  integrity sha512-3QpMge0vg4QEhHW3hBAtCipJEWjTJrqLLXdIaWptJOblf1vHFeXLNtFhPai/uX2lnFCehWNk4yOdaMR853Z02w==
 
 collection-visit@^1.0.0:
   version "1.0.0"
@@ -3000,16 +2971,6 @@ mkdirp@0.5.x, mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0:
   dependencies:
     minimist "0.0.8"
 
-monaco-editor-webpack-plugin@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-1.7.0.tgz#920cbeecca25f15d70d568a7e11b0ba4daf1ae83"
-  dependencies:
-    "@types/webpack" "^4.4.19"
-
-monaco-editor@^0.16.0, monaco-editor@^0.16.2:
-  version "0.16.2"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.16.2.tgz#950084ed82eeaef1c8c9d3c1bcab849fe11b2415"
-
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -3519,7 +3480,7 @@ promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
 
-prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.6.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   dependencies:
@@ -3641,6 +3602,11 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
+react-codemirror2@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/react-codemirror2/-/react-codemirror2-6.0.0.tgz#180065df57a64026026cde569a9708fdf7656525"
+  integrity sha512-D7y9qZ05FbUh9blqECaJMdDwKluQiO3A9xB+fssd5jKM7YAXucRuEOlX32mJQumUvHUkHRHqXIPBjm6g0FW0Ag==
+
 react-dom@^16.8.5:
   version "16.8.5"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.5.tgz#b3e37d152b49e07faaa8de41fdf562be3463335e"
@@ -3653,14 +3619,6 @@ react-dom@^16.8.5:
 react-is@^16.8.1:
   version "16.8.5"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.8.5.tgz#c54ac229dd66b5afe0de5acbe47647c3da692ff8"
-
-react-monaco-editor@*:
-  version "0.25.1"
-  resolved "https://registry.yarnpkg.com/react-monaco-editor/-/react-monaco-editor-0.25.1.tgz#29215061da23d0e4ad7bf928d9403288d5be4e92"
-  dependencies:
-    "@types/react" "*"
-    monaco-editor "^0.16.0"
-    prop-types "^15.7.2"
 
 react@^16.8.5:
   version "16.8.5"


### PR DESCRIPTION
I ended up using CodeMirror which actually ended up simplifying the code because I was able to use react-codemirror2 which interfaced well with the existing react code.