### PR TITLE
feat: use stderr when error occurs

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -88,8 +88,8 @@ const cli = argv => {
         fs.unlinkSync(inFile);
       }
     } catch (e) {
-      console.log(`error processing ${inFile}`);
-      console.log(e);
+      console.error(`error processing ${inFile}`);
+      console.error(e);
     }
   }
 };


### PR DESCRIPTION
When error occurs this library uses standard output to place error in it.
This PR changes output stream to proper one.