### PR TITLE
Rename extension to .tsx if JSX is present

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -82,7 +82,7 @@ const cli = argv => {
       const outCode = convert(inCode, options);
 
       if (program.write) {
-        const extension = detectJsx(outCode) ? ".tsx" : ".ts";
+        const extension = detectJsx(inCode) ? ".tsx" : ".ts";
         const outFile = file.replace(/\.js$/, extension);
         fs.writeFileSync(outFile, outCode);
       } else {

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,13 +3,16 @@ const fs = require("fs");
 const glob = require("glob");
 
 const convert = require("./convert.js");
-const detectJsx = require('./detect-jsx.js');
+const detectJsx = require("./detect-jsx.js");
 const version = require("../package.json").version;
 
 const cli = argv => {
   program
     .version(version)
-    .option("--inline-utility-types", "inline utility types when possible")
+    .option(
+      "--inline-utility-types",
+      "inline utility types when possible, defaults to 'false'"
+    )
     .option("--prettier", "use prettier for formatting")
     .option(
       "--semi",
@@ -33,7 +36,7 @@ const cli = argv => {
     )
     .option(
       "--bracket-spacing",
-      "put spaces between braces and contents (depends on --prettier)"
+      "put spaces between braces and contents, defaults to 'false' (depends on --prettier)"
     )
     .option(
       "--arrow-parens [avoid|always]",

--- a/src/cli.js
+++ b/src/cli.js
@@ -61,7 +61,7 @@ const cli = argv => {
     trailingComma: program.trailingComma,
     bracketSpacing: Boolean(program.bracketSpacing),
     arrowParens: program.arrowParens,
-    printWidth: program.printWidth
+    printWidth: parseInt(program.printWidth)
   };
 
   const files = new Set();

--- a/src/cli.js
+++ b/src/cli.js
@@ -3,6 +3,7 @@ const fs = require("fs");
 const glob = require("glob");
 
 const convert = require("./convert.js");
+const detectJsx = require('./detect-jsx.js');
 const version = require("../package.json").version;
 
 const cli = argv => {
@@ -78,7 +79,8 @@ const cli = argv => {
       const outCode = convert(inCode, options);
 
       if (program.write) {
-        const outFile = file.replace(/\.js$/, ".ts");
+        const extension = detectJsx(outCode) ? ".tsx" : ".ts";
+        const outFile = file.replace(/\.js$/, extension);
         fs.writeFileSync(outFile, outCode);
       } else {
         console.log(outCode);

--- a/src/convert.js
+++ b/src/convert.js
@@ -69,3 +69,4 @@ const convert = (flowCode, options) => {
 };
 
 module.exports = convert;
+module.exports.parseOptions = parseOptions;

--- a/src/detect-jsx.js
+++ b/src/detect-jsx.js
@@ -3,9 +3,9 @@ const traverse = require("../babel-traverse/lib/index.js").default;
 
 const { parseOptions } = require("./convert.js");
 
-const detectJsx = tsCode => {
+const detectJsx = code => {
   let jsx = false;
-  const ast = parse(tsCode, parseOptions);
+  const ast = parse(code, parseOptions);
 
   traverse(ast, {
     JSXOpeningElement({ node }) {

--- a/src/detect-jsx.js
+++ b/src/detect-jsx.js
@@ -1,0 +1,19 @@
+const { parse } = require("@babel/parser");
+const traverse = require("../babel-traverse/lib/index.js").default;
+
+const { parseOptions } = require("./convert.js");
+
+const detectJsx = tsCode => {
+  let jsx = false;
+  const ast = parse(tsCode, parseOptions);
+
+  traverse(ast, {
+    JSXOpeningElement({ node }) {
+      jsx = true;
+    }
+  });
+
+  return jsx;
+};
+
+module.exports = detectJsx;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1029,10 +1029,6 @@ fast-deep-equal@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz#7b05218ddf9667bf7f370bf7fdb2cb15fdd0aa49"
 
-fast-extend@0.0.2:
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/fast-extend/-/fast-extend-0.0.2.tgz#f5ec42cf40b9460f521a6387dfb52deeed671dbd"
-
 fast-json-stable-stringify@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz#d5142c0caee6b1189f87d3a76111064f86c8bbf2"
@@ -1100,10 +1096,6 @@ fragment-cache@^0.2.1:
   resolved "https://registry.yarnpkg.com/fragment-cache/-/fragment-cache-0.2.1.tgz#4290fad27f13e89be7f33799c6bc5a0abfff0d19"
   dependencies:
     map-cache "^0.2.2"
-
-fs-monkey@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/fs-monkey/-/fs-monkey-0.3.3.tgz#7960bb2b1fa2653731b9d0e2e84812a7e8b3664a"
 
 fs.realpath@^1.0.0:
   version "1.0.0"
@@ -2072,13 +2064,6 @@ mem@^4.0.0:
     map-age-cleaner "^0.1.1"
     mimic-fn "^2.0.0"
     p-is-promise "^2.0.0"
-
-memfs@^2.15.2:
-  version "2.15.2"
-  resolved "https://registry.yarnpkg.com/memfs/-/memfs-2.15.2.tgz#199b64580cf849ea641d8fac81d96742bfebd26d"
-  dependencies:
-    fast-extend "0.0.2"
-    fs-monkey "^0.3.3"
 
 merge-stream@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Thanks for a great codemod! 

When a file contains JSX it is now renamed to .tsx instead of .ts. See https://www.typescriptlang.org/docs/handbook/jsx.html

Besides, I have fixed these smaller things while testing:
- Correctly parse CLI `printWidth` as number (currently it fails if you try it using that option in the CLI)
- Update out-dated yarn.lock (installing the project showed some inconsistencies in the yarn.lock file)