### PR TITLE
Union indexers in object types

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -561,9 +561,17 @@ const transform = {
         ) {
           elements.push(indexer);
         } else {
-          const typeName = t.identifier("Record");
-          const typeParameters = t.tsTypeParameterInstantiation([key, value]);
-          spreads.push(t.tsTypeReference(typeName, typeParameters));
+          const typeParameter = t.tsTypeParameter(key);
+          typeParameter.name = indexer.parameters[0].name;
+
+          const mappedType = {
+            type: "TSMappedType",
+            typeParameter: typeParameter,
+            typeAnnotation: value,
+            optional: true
+          };
+
+          spreads.push(mappedType);
         }
       });
 

--- a/src/transform.js
+++ b/src/transform.js
@@ -551,7 +551,21 @@ const transform = {
       }
 
       // TODO: maintain the position of indexers
-      elements.push(...indexers);
+      indexers.forEach(indexer => {
+        const value = indexer.typeAnnotation.typeAnnotation;
+        const key = indexer.parameters[0].typeAnnotation.typeAnnotation;
+        if (
+          t.isTSSymbolKeyword(key) ||
+          t.isTSStringKeyword(key) ||
+          t.isTSNumberKeyword(key)
+        ) {
+          elements.push(indexer);
+        } else {
+          const typeName = t.identifier("Record");
+          const typeParameters = t.tsTypeParameterInstantiation([key, value]);
+          spreads.push(t.tsTypeReference(typeName, typeParameters));
+        }
+      });
 
       if (spreads.length > 0 && elements.length > 0) {
         path.replaceWith(

--- a/test/fixtures/convert/object-types/type-reference-indexer/flow.js
+++ b/test/fixtures/convert/object-types/type-reference-indexer/flow.js
@@ -1,0 +1,2 @@
+// @flow
+let obj: { [key: A]: string };

--- a/test/fixtures/convert/object-types/type-reference-indexer/ts.js
+++ b/test/fixtures/convert/object-types/type-reference-indexer/ts.js
@@ -1,0 +1,2 @@
+
+let obj: Record<A, string>;

--- a/test/fixtures/convert/object-types/type-reference-indexer/ts.js
+++ b/test/fixtures/convert/object-types/type-reference-indexer/ts.js
@@ -1,2 +1,2 @@
 
-let obj: Record<A, string>;
+let obj: { [key in A]?: string };

--- a/test/fixtures/convert/object-types/union-type-indexer/flow.js
+++ b/test/fixtures/convert/object-types/union-type-indexer/flow.js
@@ -1,0 +1,4 @@
+// @flow
+let obj: {
+    [key: string | number]: string
+};

--- a/test/fixtures/convert/object-types/union-type-indexer/ts.js
+++ b/test/fixtures/convert/object-types/union-type-indexer/ts.js
@@ -1,0 +1,2 @@
+
+let obj: Record<string | number, string>;

--- a/test/fixtures/convert/object-types/union-type-indexer/ts.js
+++ b/test/fixtures/convert/object-types/union-type-indexer/ts.js
@@ -1,2 +1,2 @@
 
-let obj: Record<string | number, string>;
+let obj: { [key in string | number]?: string };


### PR DESCRIPTION
Allow using unions and enums as indexers in object types. The PR converts all object types that are not TypeScript keyswords (any, string, etc) in key to a mapped type.

Fixes #108.

Instead of

```
type DayStats = {
    [key: Day]: number;
};
```

the converter now outputs:

```
type DayStats = { [key in Day]?: number; };
```

The output does not retain newlines. More work would be required to split the object definition to multiple lines.