### PR TITLE
transform SyntheticInputEvent to SyntheticEvent

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -79,7 +79,7 @@ const UnqualifiedReactTypeNameMap = {
   SyntheticAnimationEvent: "AnimationEvent",
   SyntheticClipboardEvent: "ClipboardEvent",
   SyntheticCompositionEvent: "CompositionEvent",
-  SyntheticInputEvent: "InputEvent",
+  SyntheticInputEvent: "SyntheticEvent",
   SyntheticUIEvent: "UIEvent",
   SyntheticFocusEvent: "FocusEvent",
   SyntheticKeyboardEvent: "KeyboardEvent",

--- a/test/fixtures/convert/react/events/flow.js
+++ b/test/fixtures/convert/react/events/flow.js
@@ -2,3 +2,4 @@
 const handler = (e: SyntheticEvent<>) => {};
 const animationHandler = (e: SyntheticAnimationEvent<>) => {};
 const clipboardHandler = (e: SyntheticClipboardEvent<>) => {};
+const inputHandler = (e: SyntheticInputEvent<>) => {};

--- a/test/fixtures/convert/react/events/ts.js
+++ b/test/fixtures/convert/react/events/ts.js
@@ -2,3 +2,4 @@
 const handler = (e: React.SyntheticEvent<>) => {};
 const animationHandler = (e: React.AnimationEvent<>) => {};
 const clipboardHandler = (e: React.ClipboardEvent<>) => {};
+const inputHandler = (e: React.SyntheticEvent<>) => {};


### PR DESCRIPTION
TypeScript doesn't support `InputEvent` because it's experimental currently.
https://developer.mozilla.org/en-US/docs/Web/API/InputEvent