### PR TITLE
Specify location of options

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ afterwards, e.g. changing `SyntheticEvent` to `React.Event`.
 - `yarn global add @khanacademy/flow-to-ts`
 - `flow-to-ts [options] <file globs>`
 
+For a comprehensive list of available options, please check out the [CLI code](./src/cli.js).
+
 # Playground
 
 https://flow-to-ts.netlify.com


### PR DESCRIPTION
The options aren't documented anywhere, so this PR updates to README to point to the `cli.js` file where they are defined.