### PR TITLE
Don't include a type param list if it's empty

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -365,7 +365,7 @@ const transform = {
       if (typeName.name === "Function") {
         path.replaceWith(
           t.functionTypeAnnotation(
-            null,
+            null, // type parameters
             [],
             t.functionTypeParam(
               t.identifier("args"),
@@ -417,7 +417,8 @@ const transform = {
               t.identifier("React"),
               t.identifier(UnqualifiedReactTypeNameMap[typeName.name])
             ),
-            typeParameters
+            // TypeScript doesn't support empty type param lists
+            typeParameters.params.length > 0 ? typeParameters : null
           )
         );
       } else {

--- a/test/fixtures/convert/react/events/ts.js
+++ b/test/fixtures/convert/react/events/ts.js
@@ -1,7 +1,7 @@
-const handler = (e: React.SyntheticEvent<>) => {};
+const handler = (e: React.SyntheticEvent) => {};
 
-const animationHandler = (e: React.AnimationEvent<>) => {};
+const animationHandler = (e: React.AnimationEvent) => {};
 
-const clipboardHandler = (e: React.ClipboardEvent<>) => {};
+const clipboardHandler = (e: React.ClipboardEvent) => {};
 
-const inputHandler = (e: React.SyntheticEvent<>) => {};
+const inputHandler = (e: React.SyntheticEvent) => {};


### PR DESCRIPTION
TypeScript doesn't support empty type param lists.