### PR TITLE
Fix #159, always unwrap  types

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -89,6 +89,9 @@ const utilityTypes = {
     const typeParameters = t.tsTypeParameterInstantiation([typeAnnotation]);
     return t.tsTypeReference(typeName, typeParameters);
   },
+  $Exact: typeAnnotation => {
+    return typeAnnotation;
+  },
   Class: null, // TODO
 
   // These are too complicated to inline so we'll leave them as imports
@@ -401,8 +404,10 @@ const transform = {
 
       if (typeName.name in utilityTypes) {
         if (
-          state.options.inlineUtilityTypes &&
-          typeof utilityTypes[typeName.name] === "function"
+          (state.options.inlineUtilityTypes &&
+            typeof utilityTypes[typeName.name] === "function") ||
+          // $Exact doesn't exist in utility-types so we always inline it.
+          typeName.name === "$Exact"
         ) {
           const inline = utilityTypes[typeName.name];
           path.replaceWith(inline(...typeParameters.params));

--- a/test/fixtures/convert/utility-types/$Exact/flow.js
+++ b/test/fixtures/convert/utility-types/$Exact/flow.js
@@ -1,0 +1,2 @@
+type A = $Exact<{x: number, y: number}>;
+type B = $Exact<C>;

--- a/test/fixtures/convert/utility-types/$Exact/ts.js
+++ b/test/fixtures/convert/utility-types/$Exact/ts.js
@@ -1,0 +1,5 @@
+type A = {
+  x: number;
+  y: number;
+};
+type B = C;


### PR DESCRIPTION
TypeScript doesn't have exact types so we can't convert the `$Exact` utility type.  Instead we replace it with the type that its wrapping.