### PR TITLE
Support type-only imports and exports

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -692,10 +692,6 @@ const transform = {
   },
   ExportDeclaration: {
     exit(path) {
-      if (path.node.exportKind == "type") {
-        path.node.exportKind = "value";
-      }
-
       if (path.node.source) {
         stripSuffixFromImportSource(path);
       }
@@ -703,13 +699,13 @@ const transform = {
   },
   ImportDeclaration: {
     exit(path) {
-      path.node.importKind = "value";
+      // TODO(#223): Handle "typeof" imports
       stripSuffixFromImportSource(path);
     }
   },
   ImportSpecifier: {
     exit(path) {
-      path.node.importKind = "value";
+      // TODO(#223): Handle "typeof" imports
     }
   },
   DeclareVariable: {

--- a/test/fixtures/convert/imports/default_import/ts.js
+++ b/test/fixtures/convert/imports/default_import/ts.js
@@ -1,2 +1,2 @@
-import A from "./depsA";
-import B from "../depsB";
+import type A from "./depsA";
+import type B from "../depsB";

--- a/test/fixtures/convert/imports/export_type_from/ts.js
+++ b/test/fixtures/convert/imports/export_type_from/ts.js
@@ -1,2 +1,2 @@
-export { A, B } from "./depA";
-export { C, D } from "../depB";
+export type { A, B } from "./depA";
+export type { C, D } from "../depB";

--- a/test/fixtures/convert/imports/import_node_module/ts.js
+++ b/test/fixtures/convert/imports/import_node_module/ts.js
@@ -1,1 +1,1 @@
-import A from "dep";
+import type A from "dep";

--- a/test/fixtures/convert/imports/named_import_declaration_kind/ts.js
+++ b/test/fixtures/convert/imports/named_import_declaration_kind/ts.js
@@ -1,2 +1,2 @@
-import { A, B } from "./depA";
-import { C, D } from "../depB";
+import type { A, B } from "./depA";
+import type { C, D } from "../depB";

--- a/test/fixtures/convert/imports/named_import_specifier_kind/ts.js
+++ b/test/fixtures/convert/imports/named_import_specifier_kind/ts.js
@@ -1,2 +1,2 @@
-import { A, B, C } from "./depA";
-import { D, E, F } from "../depB";
+import { type A, type B, C } from "./depA";
+import { type D, type E, F } from "../depB";

--- a/test/fixtures/convert/imports/typed_and_non_typed_imports/flow.js
+++ b/test/fixtures/convert/imports/typed_and_non_typed_imports/flow.js
@@ -1,0 +1,2 @@
+import { A } from "./depA.js";
+import type { B } from "./depA.js";

--- a/test/fixtures/convert/imports/typed_and_non_typed_imports/ts.js
+++ b/test/fixtures/convert/imports/typed_and_non_typed_imports/ts.js
@@ -1,0 +1,2 @@
+import { A } from "./depA";
+import type { B } from "./depA";


### PR DESCRIPTION
This fixes #150.  This doesn't handle `typeof` imports.  That work is being tracked by #223.