### PR TITLE
Handle variance sigils on class properties, fixes #149

### DIFF
--- a/src/transform.js
+++ b/src/transform.js
@@ -361,9 +361,23 @@ const transform = {
   },
   ClassProperty(path, state) {
     trackComments(path.node, state);
+
+    const { node } = path;
+    if (node.variance && node.variance.kind === "plus") {
+      node.readonly = true;
+    }
+    delete node.variance;
   },
   ClassPrivateProperty(path, state) {
     trackComments(path.node, state);
+
+    // There's a @babel/generator bug such that the `readonly` modifier isn't
+    // included in the output.
+    const { node } = path;
+    if (node.variance && node.variance.kind === "plus") {
+      node.readonly = true;
+    }
+    delete node.variance;
   },
 
   // All other non-leaf nodes must be processed on exit()

--- a/test/fixtures/convert/classes/readonly-class-properties/flow.js
+++ b/test/fixtures/convert/classes/readonly-class-properties/flow.js
@@ -1,0 +1,4 @@
+export default class FooBar {
+  +foo: number;
+  +#bar: number;
+}

--- a/test/fixtures/convert/classes/readonly-class-properties/ts.js
+++ b/test/fixtures/convert/classes/readonly-class-properties/ts.js
@@ -1,0 +1,4 @@
+export default class FooBar {
+  readonly foo: number;
+  #bar: number;
+}

--- a/test/fixtures/convert/classes/variance/flow.js
+++ b/test/fixtures/convert/classes/variance/flow.js
@@ -1,0 +1,4 @@
+export default class FooBar {
+  -foo: number;
+  -#bar: number;
+}

--- a/test/fixtures/convert/classes/variance/ts.js
+++ b/test/fixtures/convert/classes/variance/ts.js
@@ -1,0 +1,4 @@
+export default class FooBar {
+  foo: number;
+  #bar: number;
+}


### PR DESCRIPTION
Unfortunately there seems to be an issue with `@babel/generator`.  It doesn't include `readonly` when printing out readonly private class properties.