### PR TITLE
Use Record for object types with a single indexer

### DIFF
--- a/test/fixtures/convert/historical-types/object-generic-type-annotation/ts.js
+++ b/test/fixtures/convert/historical-types/object-generic-type-annotation/ts.js
@@ -1,3 +1,1 @@
-let a: {
-  [key: string]: any;
-};
+let a: Record<string, any>;

--- a/test/fixtures/convert/object-types/anonymous-indexer/ts.js
+++ b/test/fixtures/convert/object-types/anonymous-indexer/ts.js
@@ -1,3 +1,1 @@
-let obj: {
-  [key: number]: string;
-};
+let obj: Record<number, string>;

--- a/test/fixtures/convert/object-types/indexer01/ts.js
+++ b/test/fixtures/convert/object-types/indexer01/ts.js
@@ -1,3 +1,1 @@
-let obj: {
-  [key: number]: string;
-};
+let obj: Record<number, string>;

--- a/test/fixtures/convert/object-types/indexer02/ts.js
+++ b/test/fixtures/convert/object-types/indexer02/ts.js
@@ -1,2 +1,2 @@
 type Key = "foo" | "bar";
-let obj: { [key in Key]?: string };
+let obj: Record<Key, string>;

--- a/test/fixtures/convert/object-types/readonly-indexer/ts.js
+++ b/test/fixtures/convert/object-types/readonly-indexer/ts.js
@@ -1,3 +1,1 @@
-let obj: {
-  readonly [key: number]: string;
-};
+let obj: Readonly<Record<number, string>>;

--- a/test/fixtures/convert/object-types/type-reference-indexer/ts.js
+++ b/test/fixtures/convert/object-types/type-reference-indexer/ts.js
@@ -1,1 +1,1 @@
-let obj: { [key in A]?: string };
+let obj: Record<A, string>;

--- a/test/fixtures/convert/object-types/writeonly-indexer/ts.js
+++ b/test/fixtures/convert/object-types/writeonly-indexer/ts.js
@@ -1,3 +1,1 @@
-let obj: {
-  [key: number]: string;
-};
+let obj: Record<number, string>;


### PR DESCRIPTION
Using `React<string, number>` is more idiomatic than object type `{[key: string]: number}`.  Fixes #198.