### PR TITLE
Handle private/global React types, fixes #195

### DIFF
--- a/test/fixtures/convert/react/global-types/flow.js
+++ b/test/fixtures/convert/react/global-types/flow.js
@@ -1,0 +1,10 @@
+// @flow
+type A = React$Node;
+type B = React$Element<T>;
+type C = React$ElementType;
+type D = React$Component<Props>;
+type E = React$Component<Props, State>;
+type F = React$ComponentType<Props>;
+type G = React$Context<Props>;
+type H = React$Ref<Props>;
+type I = React$StatelessFunctionalComponent<Props>;

--- a/test/fixtures/convert/react/global-types/ts.js
+++ b/test/fixtures/convert/react/global-types/ts.js
@@ -1,0 +1,9 @@
+type A = React.ReactNode;
+type B = React.ReactElement<React.ComponentProps<T>, T>;
+type C = React.ElementType;
+type D = React.Component<Props>;
+type E = React.Component<Props, State>;
+type F = React.ComponentType<Props>;
+type G = React.Context<Props>;
+type H = React.Ref<Props>;
+type I = React.FC<Props>;


### PR DESCRIPTION
This PR does not insert `import * as React from "react"` if the import is needed.  I want to do some general refactoring first before handling that edge case.