### PR TITLE
Skip netlify build for dependabot PRs, fixes #166

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           CI: true
       - name: codecov
-        run: yarn run codecov
+        uses: codecov/codecov-action@v1
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR also attempts to fix the codecov configuration by switching to the codecov GitHub Action.