### PR TITLE
Transform mixed type/value imports to type-only imports

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -20,28 +20,53 @@
  * @param {*} state
  */
 export const trackComments = (node, state) => {
-  if (node.leadingComments) {
-    for (const comment of node.leadingComments) {
+  let leadingNode = node,
+    trailingNode = node;
+
+  if (Array.isArray(node)) {
+    leadingNode = node[0];
+    trailingNode = node[node.length - 1];
+  }
+
+  if (leadingNode.leadingComments) {
+    for (const comment of leadingNode.leadingComments) {
       const { start, end } = comment;
       const key = `${start}:${end}`;
 
       if (state.commentsToNodesMap.has(key)) {
-        state.commentsToNodesMap.get(key).leading = node;
+        state.commentsToNodesMap.get(key).leading = leadingNode;
       } else {
-        state.commentsToNodesMap.set(key, { leading: node });
+        state.commentsToNodesMap.set(key, { leading: leadingNode });
       }
     }
   }
-  if (node.trailingComments) {
-    for (const comment of node.trailingComments) {
+  if (trailingNode.trailingComments) {
+    for (const comment of trailingNode.trailingComments) {
       const { start, end } = comment;
       const key = `${start}:${end}`;
 
       if (state.commentsToNodesMap.has(key)) {
-        state.commentsToNodesMap.get(key).trailing = node;
+        state.commentsToNodesMap.get(key).trailing = trailingNode;
       } else {
-        state.commentsToNodesMap.set(key, { trailing: node });
+        state.commentsToNodesMap.set(key, { trailing: trailingNode });
       }
     }
   }
 };
+
+export function partition<T>(
+  iter: Iterable<T>,
+  fn: (val: T) => bool
+): [T[], T[]] {
+  const l = [],
+    r = [];
+  for (const v of iter) {
+    (fn(v) ? r : l).push(v);
+  }
+  return [l, r];
+}
+
+export function returning<T>(v: T, fn: (arg: T) => unknown): T {
+  fn(v);
+  return v;
+}

--- a/src/util.ts
+++ b/src/util.ts
@@ -54,10 +54,10 @@ export const trackComments = (node, state) => {
   }
 };
 
-export function partition<T>(
+export function partition<T, U extends T>(
   iter: Iterable<T>,
-  fn: (val: T) => bool
-): [T[], T[]] {
+  fn: (val: T) => val is U
+): [T[], U[]] {
   const l = [],
     r = [];
   for (const v of iter) {

--- a/test/fixtures/convert/imports/import_type_within_braces/flow.js
+++ b/test/fixtures/convert/imports/import_type_within_braces/flow.js
@@ -1,0 +1,3 @@
+// comment before
+import { type A, B } from "./a.js";
+// comment after

--- a/test/fixtures/convert/imports/import_type_within_braces/ts.js
+++ b/test/fixtures/convert/imports/import_type_within_braces/ts.js
@@ -1,0 +1,3 @@
+// comment before
+import type { A } from "./a";
+import { B } from "./a"; // comment after

--- a/test/fixtures/convert/imports/named_import_specifier_kind/ts.js
+++ b/test/fixtures/convert/imports/named_import_specifier_kind/ts.js
@@ -1,2 +1,4 @@
-import { type A, type B, C } from "./depA";
-import { type D, type E, F } from "../depB";
+import type { A, B } from "./depA";
+import { C } from "./depA";
+import type { D, E } from "../depB";
+import { F } from "../depB";


### PR DESCRIPTION
```js
import { type A, B } from "./a"
```
is invalid TypeScript, so we transform it into two statements, one
being a [type-only import](https://www.typescriptlang.org/docs/handbook/modules.html#importing-types).

Also updated `trackComments` to handle multiple nodes, which you
might have passed to `replaceWithMultiple`.