### PR TITLE
Fix duplicate import statements for multiple type imports

### DIFF
--- a/src/transform.ts
+++ b/src/transform.ts
@@ -655,6 +655,12 @@ export const transform = {
 
       if (replacementNode != null) {
         if (Array.isArray(replacementNode)) {
+          // Fixes https://github.com/Khan/flow-to-ts/issues/281
+          // Imports with multiple types will be moved to their own node leaving the source node without specifiers;
+          // do not print it as it will result in an import declaration without specifiers
+          replacementNode = replacementNode.filter(
+            (x) => x.specifiers.length > 0
+          );
           path.replaceWithMultiple(replacementNode);
         } else {
           path.replaceWith(replacementNode);

--- a/test/fixtures/convert/imports/duplicate_imports/flow.js
+++ b/test/fixtures/convert/imports/duplicate_imports/flow.js
@@ -1,0 +1,1 @@
+import { type Foo, type Baz } from "Source";

--- a/test/fixtures/convert/imports/duplicate_imports/ts.js
+++ b/test/fixtures/convert/imports/duplicate_imports/ts.js
@@ -1,0 +1,1 @@
+import type { Foo, Baz } from "Source";


### PR DESCRIPTION
Fixes #281

This is a re-authoring of #283 which @demedos [gave permission for here](https://github.com/Khan/flow-to-ts/pull/283#issuecomment-886513715).

I've added a test case to verify it works and signed the CLA.