### PR TITLE
Add options to retain lines which helps babel to preserve newlines/whitespace

### DIFF
--- a/playground/src/options-panel.tsx
+++ b/playground/src/options-panel.tsx
@@ -1,5 +1,7 @@
 import * as React from "react";
 
+import type { Options } from "../../src/types";
+
 // examples
 import basicTypes from "!!raw-loader!../examples/basic-types.js";
 import functionTypes from "!!raw-loader!../examples/function-types.js";
@@ -17,19 +19,7 @@ const examples = {
   utilityTypes,
 };
 
-export type Options = {
-  prettier: boolean;
-  prettierOptions: {
-    semi: boolean;
-    singleQuote: boolean;
-    tabWidth: number;
-    trailingComma: "all" | "es5" | "none";
-    bracketSpacing: boolean;
-    arrowParens: "avoid" | "always";
-    printWidth: number;
-  };
-  inlineUtilityTypes: boolean;
-};
+export type { Options };
 
 type Props = {
   options: Options;
@@ -246,6 +236,18 @@ class OptionsPanel extends React.Component<Props> {
               onOptionsChange({
                 ...options,
                 inlineUtilityTypes: e.currentTarget.checked,
+              });
+            }}
+          />
+          <label htmlFor="retain-lines">retain lines</label>
+          <input
+            id="retain-lines"
+            type="checkbox"
+            checked={options.retainLines}
+            onChange={(e) => {
+              onOptionsChange({
+                ...options,
+                retainLines: e.currentTarget.checked,
               });
             }}
           />

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,6 +6,7 @@ import prettier from "prettier";
 import { convert } from "./convert";
 import { detectJsx } from "./detect-jsx";
 import { version } from "../package.json";
+import type { Options } from "./types";
 
 export const cli = (argv) => {
   const program = new Command();
@@ -47,6 +48,10 @@ export const cli = (argv) => {
       "avoid"
     )
     .option("--print-width [width]", "line width (depends on --prettier)", 80)
+    .option(
+      "--retain-lines",
+      "have babel try to retain original line numbers which may help preserve whitespace (recommended to be used with --prettier)"
+    )
     .option("--write", "write output to disk instead of STDOUT")
     .option("--delete-source", "delete the source file");
 
@@ -59,7 +64,7 @@ export const cli = (argv) => {
 
   const options = {
     inlineUtilityTypes: Boolean(program.inlineUtilityTypes),
-    prettier: program.prettier,
+    prettier: Boolean(program.prettier),
     prettierOptions: {
       semi: Boolean(program.semi),
       singleQuote: Boolean(program.singleQuote),
@@ -69,7 +74,8 @@ export const cli = (argv) => {
       arrowParens: program.arrowParens,
       printWidth: parseInt(program.printWidth),
     },
-  };
+    retainLines: Boolean(program.retainLines),
+  } as Options;
 
   if (options.prettier) {
     try {

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -6,6 +6,7 @@ const plugins = [require("prettier/parser-typescript.js")];
 
 import { transform } from "./transform";
 import type { ParserOptions } from "@babel/parser";
+import type { Options } from "./types";
 
 export const parseOptions: ParserOptions = {
   sourceType: "module",
@@ -53,7 +54,7 @@ const fixComments = (commentsToNodesMap) => {
   }
 };
 
-export const convert = (flowCode: string, options?: any) => {
+export const convert = (flowCode: string, options?: Options) => {
   const ast = parse(flowCode, parseOptions);
 
   // key = startLine:endLine, value = {leading, trailing} (nodes)
@@ -81,7 +82,11 @@ export const convert = (flowCode: string, options?: any) => {
 
   // we pass flowCode so that generate can compute source maps
   // if we ever decide to
-  let tsCode = generate(ast, undefined, flowCode).code;
+  let tsCode = generate(
+    ast,
+    { retainLines: options && options.retainLines },
+    flowCode
+  ).code;
 
   if (options && options.prettier) {
     const prettierOptions = {

--- a/src/detect-jsx.ts
+++ b/src/detect-jsx.ts
@@ -3,7 +3,7 @@ import traverse from "@babel/traverse";
 
 import { parseOptions } from "./convert";
 
-export const detectJsx = (code) => {
+export const detectJsx = (code: string): boolean => {
   let jsx = false;
   const ast = parse(code, parseOptions);
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,15 @@
+export type Options = {
+  inlineUtilityTypes: boolean;
+  prettier: boolean;
+  prettierOptions: {
+    semi: boolean;
+    singleQuote: boolean;
+    tabWidth: number;
+    trailingComma: "all" | "es5" | "none";
+    bracketSpacing: boolean;
+    arrowParens: "avoid" | "always";
+    printWidth: number;
+  };
+  retainLines: boolean;
+  debug: boolean;
+};

--- a/test/fixtures/convert/formatting/retain_lines/flow.js
+++ b/test/fixtures/convert/formatting/retain_lines/flow.js
@@ -1,0 +1,17 @@
+import type { Something } from "Source";
+
+type Another = {|
+  key: string,
+|};
+
+/*
+ * This is a comment
+ */
+
+// Another comment
+
+function Hello() {
+  const example = 1;
+
+  return null
+}

--- a/test/fixtures/convert/formatting/retain_lines/options.json
+++ b/test/fixtures/convert/formatting/retain_lines/options.json
@@ -1,0 +1,4 @@
+{
+  "retainLines": true,
+  "prettier": true
+}

--- a/test/fixtures/convert/formatting/retain_lines/ts.js
+++ b/test/fixtures/convert/formatting/retain_lines/ts.js
@@ -1,0 +1,17 @@
+import type { Something } from "Source";
+
+type Another = {
+  key: string;
+};
+
+/*
+ * This is a comment
+ */
+
+// Another comment
+
+function Hello() {
+  const example = 1;
+
+  return null;
+}

--- a/test/fixtures/convert/formatting/retain_lines_off/flow.js
+++ b/test/fixtures/convert/formatting/retain_lines_off/flow.js
@@ -1,0 +1,17 @@
+import type { Something } from "Source";
+
+type Another = {|
+  key: string,
+|};
+
+/*
+ * This is a comment
+ */
+
+// Another comment
+
+function Hello() {
+  const example = 1;
+
+  return null
+}

--- a/test/fixtures/convert/formatting/retain_lines_off/options.json
+++ b/test/fixtures/convert/formatting/retain_lines_off/options.json
@@ -1,0 +1,4 @@
+{
+  "retainLines": false,
+  "prettier": true
+}

--- a/test/fixtures/convert/formatting/retain_lines_off/ts.js
+++ b/test/fixtures/convert/formatting/retain_lines_off/ts.js
@@ -1,0 +1,13 @@
+import type { Something } from "Source";
+type Another = {
+  key: string;
+};
+
+/*
+ * This is a comment
+ */
+// Another comment
+function Hello() {
+  const example = 1;
+  return null;
+}

--- a/test/fixtures/convert/formatting/retain_lines_ugly/flow.js
+++ b/test/fixtures/convert/formatting/retain_lines_ugly/flow.js
@@ -1,0 +1,17 @@
+import type { Something } from "Source";
+
+type Another = {|
+  key: string,
+|};
+
+/*
+ * This is a comment
+ */
+
+// Another comment
+
+function Hello() {
+  const example = 1;
+
+  return null
+}

--- a/test/fixtures/convert/formatting/retain_lines_ugly/options.json
+++ b/test/fixtures/convert/formatting/retain_lines_ugly/options.json
@@ -1,0 +1,4 @@
+{
+  "retainLines": true,
+  "prettier": false
+}

--- a/test/fixtures/convert/formatting/retain_lines_ugly/ts.js
+++ b/test/fixtures/convert/formatting/retain_lines_ugly/ts.js
@@ -1,0 +1,17 @@
+import type { Something } from "Source";
+
+type Another = {
+  key: string;};
+
+
+/*
+ * This is a comment
+ */
+
+// Another comment
+
+function Hello() {
+  const example = 1;
+
+  return null;
+}


### PR DESCRIPTION
Implements a `--retain-lines` option to pass through to Babel's [`retainLines` option](https://babeljs.io/docs/en/options#retainlines). This allows Babel to try and preserve line positions when generating output code -- the resulting output can be quite ugly, but prettier does a great job of cleaning it up.

## Input
```js
import type { Something } from "Source";

type Another = {|
  key: string,
|};

/*
 * This is a comment
 */

// Another comment

function Hello() {
  const example = 1;

  return null
}
```

## Output

<table>
<tr>
<th>Before</th><th>After</th>
</tr>
<tr>
<td>

```js
import type { Something } from "Source";
type Another = {
  key: string;
};

/*
 * This is a comment
 */
// Another comment
function Hello() {
  const example = 1;
  return null;
}
```

</td>
<td>

```js
import type { Something } from "Source";

type Another = {
  key: string;
};

/*
 * This is a comment
 */

// Another comment

function Hello() {
  const example = 1;

  return null;
}
```

</td>
</tr>
</table>


Fixes #237