### PR TITLE
Convert $Diff<T, U> -> Omit<T, keyof U>

### DIFF
--- a/src/transforms/utility-types.ts
+++ b/src/transforms/utility-types.ts
@@ -55,10 +55,22 @@ const utilityTypes = {
   $FlowFixMe: () => {
     return t.tsAnyKeyword();
   },
-  Class: null, // TODO
+  $Diff: (T, U) => {
+    // $Diff<T, U> -> Omit<T, keyof U>
+    const typeName = t.identifier("Omit");
+    // TODO: patch @babel/types - tsTypeOperator should accept two arguments
+    // const keyof = t.tsTypeOperator(typeAnnotation, "keyof");
+    const keyofU = {
+      type: "TSTypeOperator",
+      typeAnnotation: U,
+      operator: "keyof",
+    };
+    const typeParameters = t.tsTypeParameterInstantiation([T, keyofU]);
+    return t.tsTypeReference(typeName, typeParameters);
+  },
 
+  Class: null, // TODO
   // These are too complicated to inline so we'll leave them as imports
-  $Diff: null,
   $ElementType: null,
   $Call: null,
 

--- a/test/fixtures/convert/utility-types/$Diff/flow.js
+++ b/test/fixtures/convert/utility-types/$Diff/flow.js
@@ -1,1 +1,0 @@
-type B = $Diff<A>;

--- a/test/fixtures/convert/utility-types/$Diff_import/flow.js
+++ b/test/fixtures/convert/utility-types/$Diff_import/flow.js
@@ -1,0 +1,1 @@
+type C = $Diff<A, B>;

--- a/test/fixtures/convert/utility-types/$Diff_import/ts.js
+++ b/test/fixtures/convert/utility-types/$Diff_import/ts.js
@@ -1,2 +1,2 @@
 import { $Diff } from "utility-types";
-type B = $Diff<A>;
+type C = $Diff<A, B>;

--- a/test/fixtures/convert/utility-types/$Diff_inline/flow.js
+++ b/test/fixtures/convert/utility-types/$Diff_inline/flow.js
@@ -1,0 +1,1 @@
+type C = $Diff<A, B>;

--- a/test/fixtures/convert/utility-types/$Diff_inline/options.json
+++ b/test/fixtures/convert/utility-types/$Diff_inline/options.json
@@ -1,0 +1,1 @@
+{"inlineUtilityTypes": true}

--- a/test/fixtures/convert/utility-types/$Diff_inline/ts.js
+++ b/test/fixtures/convert/utility-types/$Diff_inline/ts.js
@@ -1,0 +1,1 @@
+type C = Omit<A, keyof B>;


### PR DESCRIPTION
This is a lossy conversion, since Flow requires that `U` is an object type and that `T` (1) has all the keys of `U` and (2) the corresponding values of `T` are assignable to those of `U`. A closer analogue would use `OmitStrict` instead of `Omit` (where `type OmitStrict<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>`) but using the standard `Omit` means we don't need to add potentially-conflicting definitions elsewhere to import here.