### PR TITLE
React: rewrite unqualified React imports; update Fragment, Children and ChildrenArray transforms.

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -67,6 +67,7 @@ export const convert = (flowCode: string, options?: any) => {
   // apply our transforms, traverse mutates the ast
   const state = {
     usedUtilityTypes: new Set(),
+    unqualifiedReactImports: new Set(),
     options: Object.assign({ inlineUtilityTypes: false }, options),
     commentsToNodesMap,
     startLineToComments,

--- a/src/transform.ts
+++ b/src/transform.ts
@@ -660,13 +660,21 @@ export const transform = {
           path.replaceWith(replacementNode);
         }
       }
+
+      reactTypes.ImportDeclaration.exit(path, state);
     },
   },
   ImportSpecifier: {
-    exit(path) {
+    exit(path, state) {
       // TODO(#223): Handle "typeof" imports.
       if (path.node.importKind === "typeof") {
         path.node.importKind = "value";
+      }
+
+      const replacement = reactTypes.ImportSpecifier.exit(path, state);
+      if (replacement) {
+        path.replaceWith(replacement);
+        return;
       }
     },
   },

--- a/src/transforms/react-types.ts
+++ b/src/transforms/react-types.ts
@@ -43,8 +43,14 @@ export const ImportDeclaration = {
           } else {
             return false;
           }
+        } else if (
+          n.local?.name === "ChildrenArray" &&
+          n.imported?.name === "ChildrenArray"
+        ) {
+          return false;
+        } else {
+          return true;
         }
-        return true;
       });
     }
   },
@@ -143,6 +149,16 @@ export const GenericTypeAnnotation = {
     }
 
     if (
+      typeName.name === "ChildrenArray" &&
+      state.unqualifiedReactImports.has("ChildrenArray")
+    ) {
+      return t.tsUnionType([
+        typeParameters.params[0],
+        t.tsArrayType(typeParameters.params[0]),
+      ]);
+    }
+
+    if (
       typeName.name === "ElementConfig" &&
       state.unqualifiedReactImports.has("ElementConfig")
     ) {
@@ -186,6 +202,16 @@ export const GenericTypeAnnotation = {
             ),
           ])
         );
+      }
+
+      if (
+        t.isIdentifier(left, { name: "React" }) &&
+        t.isIdentifier(right, { name: "ChildrenArray" })
+      ) {
+        return t.tsUnionType([
+          typeParameters.params[0],
+          t.tsArrayType(typeParameters.params[0]),
+        ]);
       }
     }
   },

--- a/src/transforms/react-types.ts
+++ b/src/transforms/react-types.ts
@@ -1,5 +1,55 @@
 import * as t from "@babel/types";
 
+export const ImportSpecifier = {
+  exit(path, state) {
+    const { local, imported } = path.node;
+
+    if (
+      path.parent.source.value === "react" &&
+      // TODO: Support transforming unqualified React types imported as aliases.
+      local.name === imported.name
+    ) {
+      state.unqualifiedReactImports.add(local.name);
+
+      if (local.name in QualifiedReactTypeNameMap) {
+        return t.importSpecifier(
+          t.identifier(QualifiedReactTypeNameMap[local.name]),
+          t.identifier(QualifiedReactTypeNameMap[local.name])
+        );
+      }
+
+      if (local.name === "ElementConfig") {
+        return t.importSpecifier(
+          t.identifier("ComponentProps"),
+          t.identifier("ComponentProps")
+        );
+      }
+    }
+  },
+};
+
+export const ImportDeclaration = {
+  exit(path, state) {
+    if (path.node?.source?.value === "react") {
+      let seenComponentProps = false;
+      path.node.specifiers = (path.node.specifiers ?? []).filter((n) => {
+        if (
+          n.local?.name === "ComponentProps" &&
+          n.imported?.name === "ComponentProps"
+        ) {
+          if (!seenComponentProps) {
+            seenComponentProps = true;
+            return true;
+          } else {
+            return false;
+          }
+        }
+        return true;
+      });
+    }
+  },
+};
+
 export const GenericTypeAnnotation = {
   exit(path, state) {
     const { id: typeName, typeParameters } = path.node;
@@ -12,7 +62,18 @@ export const GenericTypeAnnotation = {
           t.identifier(UnqualifiedReactTypeNameMap[typeName.name])
         ),
         // TypeScript doesn't support empty type param lists
-        typeParameters && typeParameters.params.length > 0 ? typeParameters : null
+        typeParameters && typeParameters.params.length > 0
+          ? typeParameters
+          : null
+      );
+    }
+
+    if (
+      typeName.name in QualifiedReactTypeNameMap &&
+      state.unqualifiedReactImports.has(typeName.name)
+    ) {
+      return t.tsTypeReference(
+        t.identifier(QualifiedReactTypeNameMap[typeName.name])
       );
     }
 
@@ -81,6 +142,26 @@ export const GenericTypeAnnotation = {
       );
     }
 
+    if (
+      typeName.name === "ElementConfig" &&
+      state.unqualifiedReactImports.has("ElementConfig")
+    ) {
+      // ElementConfig<T> -> JSX.LibraryManagedAttributes<T, ComponentProps<T>>
+      return t.tsTypeReference(
+        t.tsQualifiedName(
+          t.identifier("JSX"),
+          t.identifier("LibraryManagedAttributes")
+        ),
+        t.tsTypeParameterInstantiation([
+          typeParameters.params[0],
+          t.tsTypeReference(
+            t.identifier("ComponentProps"),
+            t.tsTypeParameterInstantiation([typeParameters.params[0]])
+          ),
+        ])
+      );
+    }
+
     if (t.isTSQualifiedName(typeName)) {
       const { left, right } = typeName;
 
@@ -107,7 +188,7 @@ export const GenericTypeAnnotation = {
         );
       }
     }
-  }
+  },
 };
 
 // Mapping between React types for Flow and those for TypeScript.
@@ -144,7 +225,7 @@ export const QualifiedTypeIdentifier = {
         t.identifier(QualifiedReactTypeNameMap[right.name])
       );
     }
-  }
+  },
 };
 
 // Only types with different names are included.

--- a/src/transforms/react-types.ts
+++ b/src/transforms/react-types.ts
@@ -233,9 +233,7 @@ const QualifiedReactTypeNameMap = {
   Node: "ReactNode",
   Text: "ReactText",
   Child: "ReactChild",
-  Children: "ReactChildren",
   Element: "ReactElement", // 1:1 mapping is wrong, since ReactElement takes two type params
-  Fragment: "ReactFragment",
   Portal: "ReactPortal",
   NodeArray: "ReactNodeArray",
 

--- a/test/fixtures/convert/react/basic-types-different-unqualified/flow.js
+++ b/test/fixtures/convert/react/basic-types-different-unqualified/flow.js
@@ -1,19 +1,8 @@
 // @flow
-import {
-  Node,
-  Text,
-  Child,
-  Children,
-  Fragment,
-  Portal,
-  NodeArray,
-  Element,
-} from "react";
+import { Node, Text, Child, Portal, NodeArray, Element } from "react";
 let node: Node;
 let text: Text;
 let child: Child;
-let children: Children;
-let fragment: Fragment;
 let portal: Portal;
 let nodeArray: NodeArray;
 let element: Element;

--- a/test/fixtures/convert/react/basic-types-different-unqualified/flow.js
+++ b/test/fixtures/convert/react/basic-types-different-unqualified/flow.js
@@ -1,8 +1,17 @@
 // @flow
-import { Node, Text, Child, Portal, NodeArray, Element } from "react";
+import {
+  Node,
+  Text,
+  Child,
+  Portal,
+  NodeArray,
+  Element,
+  ChildrenArray,
+} from "react";
 let node: Node;
 let text: Text;
 let child: Child;
 let portal: Portal;
 let nodeArray: NodeArray;
 let element: Element;
+let children: ChildrenArray<T>;

--- a/test/fixtures/convert/react/basic-types-different-unqualified/flow.js
+++ b/test/fixtures/convert/react/basic-types-different-unqualified/flow.js
@@ -1,0 +1,19 @@
+// @flow
+import {
+  Node,
+  Text,
+  Child,
+  Children,
+  Fragment,
+  Portal,
+  NodeArray,
+  Element,
+} from "react";
+let node: Node;
+let text: Text;
+let child: Child;
+let children: Children;
+let fragment: Fragment;
+let portal: Portal;
+let nodeArray: NodeArray;
+let element: Element;

--- a/test/fixtures/convert/react/basic-types-different-unqualified/options.json
+++ b/test/fixtures/convert/react/basic-types-different-unqualified/options.json
@@ -1,0 +1,9 @@
+{
+    "prettier": true,
+    "prettierOptions": {
+        "semi": true,
+        "singleQuote": false,
+        "tabWidth": 2,
+        "trailingComma": "all"
+    }
+}

--- a/test/fixtures/convert/react/basic-types-different-unqualified/ts.js
+++ b/test/fixtures/convert/react/basic-types-different-unqualified/ts.js
@@ -1,0 +1,18 @@
+import {
+  ReactNode,
+  ReactText,
+  ReactChild,
+  ReactChildren,
+  ReactFragment,
+  ReactPortal,
+  ReactNodeArray,
+  ReactElement,
+} from "react";
+let node: ReactNode;
+let text: ReactText;
+let child: ReactChild;
+let children: ReactChildren;
+let fragment: ReactFragment;
+let portal: ReactPortal;
+let nodeArray: ReactNodeArray;
+let element: ReactElement;

--- a/test/fixtures/convert/react/basic-types-different-unqualified/ts.js
+++ b/test/fixtures/convert/react/basic-types-different-unqualified/ts.js
@@ -2,8 +2,6 @@ import {
   ReactNode,
   ReactText,
   ReactChild,
-  ReactChildren,
-  ReactFragment,
   ReactPortal,
   ReactNodeArray,
   ReactElement,
@@ -11,8 +9,6 @@ import {
 let node: ReactNode;
 let text: ReactText;
 let child: ReactChild;
-let children: ReactChildren;
-let fragment: ReactFragment;
 let portal: ReactPortal;
 let nodeArray: ReactNodeArray;
 let element: ReactElement;

--- a/test/fixtures/convert/react/basic-types-different-unqualified/ts.js
+++ b/test/fixtures/convert/react/basic-types-different-unqualified/ts.js
@@ -12,3 +12,4 @@ let child: ReactChild;
 let portal: ReactPortal;
 let nodeArray: ReactNodeArray;
 let element: ReactElement;
+let children: T | T[];

--- a/test/fixtures/convert/react/basic-types-different/flow.js
+++ b/test/fixtures/convert/react/basic-types-different/flow.js
@@ -3,8 +3,6 @@ import * as React from "react";
 let node: React.Node;
 let text: React.Text;
 let child: React.Child;
-let children: React.Children;
-let fragment: React.Fragment;
 let portal: React.Portal;
 let nodeArray: React.NodeArray;
 let element: React.Element;

--- a/test/fixtures/convert/react/basic-types-different/flow.js
+++ b/test/fixtures/convert/react/basic-types-different/flow.js
@@ -6,3 +6,4 @@ let child: React.Child;
 let portal: React.Portal;
 let nodeArray: React.NodeArray;
 let element: React.Element;
+let children: React.ChildrenArray<T>;

--- a/test/fixtures/convert/react/basic-types-different/ts.js
+++ b/test/fixtures/convert/react/basic-types-different/ts.js
@@ -2,8 +2,6 @@ import * as React from "react";
 let node: React.ReactNode;
 let text: React.ReactText;
 let child: React.ReactChild;
-let children: React.ReactChildren;
-let fragment: React.ReactFragment;
 let portal: React.ReactPortal;
 let nodeArray: React.ReactNodeArray;
 let element: React.ReactElement;

--- a/test/fixtures/convert/react/basic-types-different/ts.js
+++ b/test/fixtures/convert/react/basic-types-different/ts.js
@@ -5,3 +5,4 @@ let child: React.ReactChild;
 let portal: React.ReactPortal;
 let nodeArray: React.ReactNodeArray;
 let element: React.ReactElement;
+let children: T | T[];

--- a/test/fixtures/convert/react/basic-types-same/flow.js
+++ b/test/fixtures/convert/react/basic-types-same/flow.js
@@ -6,3 +6,5 @@ let componentType: React.ComponentType;
 let context: React.Context;
 let ref: React.Ref;
 let key: React.Key;
+let children: React.Children;
+let fragment: React.Fragment;

--- a/test/fixtures/convert/react/basic-types-same/ts.js
+++ b/test/fixtures/convert/react/basic-types-same/ts.js
@@ -5,3 +5,5 @@ let componentType: React.ComponentType;
 let context: React.Context;
 let ref: React.Ref;
 let key: React.Key;
+let children: React.Children;
+let fragment: React.Fragment;

--- a/test/fixtures/convert/react/colliding-types-unqualified/flow.js
+++ b/test/fixtures/convert/react/colliding-types-unqualified/flow.js
@@ -14,3 +14,4 @@ let context: Context;
 let ref: Ref;
 let key: Key;
 let elementConfig: ElementConfig;
+let chilernArray: ChildrenArray;

--- a/test/fixtures/convert/react/colliding-types-unqualified/flow.js
+++ b/test/fixtures/convert/react/colliding-types-unqualified/flow.js
@@ -1,0 +1,16 @@
+// @flow
+let node: Node;
+let text: Text;
+let child: Child;
+let children: Children;
+let fragment: Fragment;
+let portal: Portal;
+let nodeArray: NodeArray;
+let element: Element;
+let component: Component;
+let pureComponent: PureComponent;
+let componentType: ComponentType;
+let context: Context;
+let ref: Ref;
+let key: Key;
+let elementConfig: ElementConfig;

--- a/test/fixtures/convert/react/colliding-types-unqualified/ts.js
+++ b/test/fixtures/convert/react/colliding-types-unqualified/ts.js
@@ -1,0 +1,15 @@
+let node: Node;
+let text: Text;
+let child: Child;
+let children: Children;
+let fragment: Fragment;
+let portal: Portal;
+let nodeArray: NodeArray;
+let element: Element;
+let component: Component;
+let pureComponent: PureComponent;
+let componentType: ComponentType;
+let context: Context;
+let ref: Ref;
+let key: Key;
+let elementConfig: ElementConfig;

--- a/test/fixtures/convert/react/colliding-types-unqualified/ts.js
+++ b/test/fixtures/convert/react/colliding-types-unqualified/ts.js
@@ -13,3 +13,4 @@ let context: Context;
 let ref: Ref;
 let key: Key;
 let elementConfig: ElementConfig;
+let chilernArray: ChildrenArray;

--- a/test/fixtures/convert/react/element-config-unqualified/flow.js
+++ b/test/fixtures/convert/react/element-config-unqualified/flow.js
@@ -1,0 +1,4 @@
+// @flow
+// Include an unused reference to ComponentProps to ensure we don't import it twice.
+import { ElementConfig, ComponentProps } from "react";
+type Props = ElementConfig<T>;

--- a/test/fixtures/convert/react/element-config-unqualified/ts.js
+++ b/test/fixtures/convert/react/element-config-unqualified/ts.js
@@ -1,0 +1,3 @@
+// Include an unused reference to ComponentProps to ensure we don't import it twice.
+import { ComponentProps } from "react";
+type Props = JSX.LibraryManagedAttributes<T, ComponentProps<T>>;


### PR DESCRIPTION
This PR does a few React-related things.

## Unqualified Imports

This PR supports transformations such as

```js
// @flow
import { Node } from 'react';
let node: Node;
```

to

```ts
import { ReactNode } from 'react';
let node: ReactNode;
```

Previously, rewriting names like this was only supported for unambiguously namespaced references like `React.Node` to `React.ReactNode`.

The gist of the changes is:
- collect references to imported unqualified type names from packages called `react`
- if we see a rewritable type name _and_ we have already seen an import of it, then we rewrite it

There's two known issues with the current approach:
- if there is an unqualified type already imported that collides with one from React, we will still rewrite the import and references to it, but we will now have two imports of the same name as well as ambiguous references to the type at the usage sites
- aliased imports are not supported (e.g. `import { Node as RNode } from 'react';`) and will no-op

I'm not sure if these tradeoffs are acceptable for the goals of the project. They can be worked around with more effort, but a complete solution will require multiple passes over the file (since we will want to find all imports before we make any decisions about which types to rewrite), which is at odds with the current architecture. The current implementation is optimistic that it won't cause collisions and does not check.

## `Fragment` and `Children` No Longer Renamed

These two types have equivalents in the TypeScript typings. Rewriting these names would break working code of the form

```js
import { Fragment, Children } from 'react';
```

as both of those identifiers are runtime values with the same name as their corresponding types. There are no `React.ReactFragment` or `React.ReactChildren` runtime values, though there are types.

## `ChildrenArray<T>` Replaced with `T | T[]`

I don't know if TypeScript ever had a type for this, but it doesn't now. If you look at the type definitions for the `React.Children` object, you'll see they don't bother with an intermediate React-aware children "array" type, and instead just take a union like `T | T[]`. So now `flow-to-ts` performs the same mapping, removing any `ChildrenArray` import entirely.